### PR TITLE
patch-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Auto-sync files or directories over SSH using [fs.**watch**()](https://nodejs.or
 Comes with a nifty tool ```sshpair``` that generates a public SSH key with
 
 ```bash
-echo -e "y\n" | ssh-keygen -q -N "" -f ~/.ssh/id_rsa
+echo -e "y\n" | ssh-keygen -q -N "" -f ~/.ssh/sshync
 ```
 
 and writes the result to ```~/.ssh/authorized_keys``` on the remote host. This prevents the password prompt from showing up every time we sync.
@@ -38,10 +38,10 @@ $ sshync <user@ip[:port]> <source> <destination>
 $ git clone https://github.com/mateogianolio/sshync.git
 $ cd sshync
 $ sshpair root@xxx.xxx.82.203
-generated ssh key to ~/.ssh/id_rsa.pub
+generated ssh key to ~/.ssh/sshync.pub
 root@xxx.xxx.82.203's password:
 root@xxx.xxx.82.203's password:
-~/.ssh/id_rsa.pub => ~/.ssh/authorized_keys
+~/.ssh/sshync.pub => ~/.ssh/authorized_keys
 
 $ echo -e ".git\nnode_modules" > .sshyncignore
 $ sshync root@xxx.xxx.82.203 . /root/sshync

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sshync",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "auto-sync files over ssh",
   "main": "sshync.js",
   "bin": {

--- a/sshpair.js
+++ b/sshpair.js
@@ -24,19 +24,19 @@
   var host_ip = host.pop(),
       host_user = host.pop();
 
-  cp.exec('echo -e "y\n" | ssh-keygen -q -N "" -f ~/.ssh/id_rsa', () => {});
-  console.log('generated ssh key to', '~/.ssh/id_rsa.pub'.blue);
+  cp.exec('echo -e "y\n" | ssh-keygen -q -N "" -f ~/.ssh/sshync', () => {});
+  console.log('generated ssh key to', '~/.ssh/sshync.pub'.blue);
 
   var client = ssh(host_user, host_ip, () => {
     client.exec('mkdir -p ~/.ssh', (error, stdout, stderr) => {
       if (error)
         throw error;
 
-      client.putFile('~/.ssh/id_rsa.pub', '~/.ssh/authorized_keys', (error, stdout, stderr) => {
+      client.putFile('~/.ssh/sshync.pub', '~/.ssh/authorized_keys', (error, stdout, stderr) => {
         if (error)
           throw error;
 
-        console.log('~/.ssh/id_rsa.pub'.blue, '=>', '~/.ssh/authorized_keys'.green);
+        console.log('~/.ssh/sshync.pub'.blue, '=>', '~/.ssh/authorized_keys'.green);
         process.exit();
       });
     });


### PR DESCRIPTION
fix #4, now outputs key to `~/.ssh/sshync` and `~/.ssh/sshync.pub` respectively.
