### PR TITLE
Delete extraneous files

### DIFF
--- a/sshync.js
+++ b/sshync.js
@@ -23,6 +23,7 @@
       cmd = new rsync()
         .shell('ssh')
         .flags('avuz')
+        .delete() // This tells rsync to delete extraneous files from the receiving side
         .source(source)
         .destination(args[1]),
       handle;


### PR DESCRIPTION
When syncing git repo, it happens when some files got deleted. Keep those deleted files can be problematic for compile and run.
Deleting them so the two folders are 100% in sync.